### PR TITLE
fix(fgdpp): add #include <algorithm> to fix missing find_if on linux

### DIFF
--- a/src/fgdpp/fgdpp.cpp
+++ b/src/fgdpp/fgdpp.cpp
@@ -2,6 +2,7 @@
 
 #include <charconv>
 #include <filesystem>
+#include <algorithm>
 
 #include <BufferStream.h>
 


### PR DESCRIPTION
Whenever compiling vpkedit 4.2.3 on arch, I get the following error:

```
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp: In function ‘void {anonymous}::overwriteEntity(fgdpp::FGD::Entity&, fgdpp::FGD::Entity&)’:
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:350:36: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  350 |                 if (auto it = std::find_if(oldEntity.fields.begin(), oldEntity.fields.end(), [&field](const auto& oldField) {
      |                                    ^~~~~~~
      |                                    find
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:370:36: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  370 |                 if (auto it = std::find_if(oldEntity.fieldsWithChoices.begin(), oldEntity.fieldsWithChoices.end(), [&field](const auto& oldField) {
      |                                    ^~~~~~~
      |                                    find
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:390:36: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  390 |                 if (auto it = std::find_if(oldEntity.fieldsWithFlags.begin(), oldEntity.fieldsWithFlags.end(), [&field](const auto& oldField) {
      |                                    ^~~~~~~
      |                                    find
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:401:36: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  401 |                 if (auto it = std::find_if(oldEntity.inputs.begin(), oldEntity.inputs.end(), [&input](const auto& oldInput) {
      |                                    ^~~~~~~
      |                                    find
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:413:36: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  413 |                 if (auto it = std::find_if(oldEntity.outputs.begin(), oldEntity.outputs.end(), [&output](const auto& oldOutput) {
      |                                    ^~~~~~~
      |                                    find
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp: In member function ‘void fgdpp::FGD::readEntities(BufferStreamReadOnly&, const std::string&, std::vector<std::__cxx11::basic_string<char> >&)’:
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:525:38: error: no matching function for call to ‘find(std::vector<std::__cxx11::basic_string<char> >::iterator, std::vector<std::__cxx11::basic_string<char> >::iterator, std::__cxx11::basic_string<char>&)’
  525 |                         if (std::find(seenPaths.begin(), seenPaths.end(), fgdPath) != seenPaths.end()) {
      |                             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14.1.1/bits/locale_facets.h:48,
                 from /usr/include/c++/14.1.1/locale:42,
                 from /usr/include/c++/14.1.1/bits/fs_path.h:36,
                 from /usr/include/c++/14.1.1/filesystem:52,
                 from /home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:4:
/usr/include/c++/14.1.1/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14.1.1/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
/home/hurricane/aur/vpkedit/src/vpkedit/src/shared/thirdparty/sourcepp/src/fgdpp/fgdpp.cpp:525:38: note:   ‘__gnu_cxx::__normal_iterator<std::__cxx11::basic_string<char>*, std::vector<std::__cxx11::basic_string<char> > >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
  525 |                         if (std::find(seenPaths.begin(), seenPaths.end(), fgdPath) != seenPaths.end()) {
      |                             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This can be fixed by adding `#include <algorithm>` to `src/fgdpp/fgdpp.cpp`