### PR TITLE
feat(vpkpp): VPK v54

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "ext/hat-trie"]
 	path = ext/hat-trie
 	url = https://github.com/Tessil/hat-trie
+[submodule "ext/zstd"]
+	path = ext/zstd
+	url = https://github.com/facebook/zstd

--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ Several modern C++20 libraries for sanely parsing Valve formats, rolled into one
   </tr>
   <tr><!-- empty row to disable github striped bg color --></tr>
   <tr>
-    <td><a href="https://developer.valvesoftware.com/wiki/VPK">VPK</a> v1-2</td>
+    <td>
+      <a href="https://developer.valvesoftware.com/wiki/VPK">VPK</a> v1-2, v54
+      <br> &bull; <a href="https://www.counter-strike.net/cs2">Counter-Strike: 2</a> modifications
+      <br> &bull; <a href="https://clientmod.ru">Counter-Strike: Source ClientMod</a> modifications
+    </td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,7 +162,11 @@ Several modern C++20 libraries for sanely parsing Valve formats, rolled into one
     <td align="center">✅</td>
   </tr>
   <tr>
-    <td><a href="https://developer.valvesoftware.com/wiki/VPK">VPK</a> v1-2</td>
+    <td>
+      <a href="https://developer.valvesoftware.com/wiki/VPK">VPK</a> v1-2, v54
+      <br> &bull; <a href="https://www.counter-strike.net/cs2">Counter-Strike: 2</a> modifications
+      <br> &bull; <a href="https://clientmod.ru">Counter-Strike: Source ClientMod</a> modifications
+    </td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>

--- a/ext/_ext.cmake
+++ b/ext/_ext.cmake
@@ -37,19 +37,27 @@ if(NOT TARGET miniz)
 endif()
 
 
+# zstd
+if(NOT TARGET zstd::libzstd)
+    set(ZSTD_BUILD_PROGRAMS OFF CACHE INTERNAL "" FORCE)
+    set(ZSTD_BUILD_TESTS    OFF CACHE INTERNAL "" FORCE)
+    add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/zstd/build/cmake")
+    # find_package hacks
+    set(ZSTD_FOUND ON CACHE INTERNAL "" FORCE)
+    set(ZSTD_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/ext/zstd/lib" CACHE INTERNAL "" FORCE)
+    set(ZSTD_LIBRARY_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/ext/zstd/lib" CACHE INTERNAL "" FORCE)
+    set(ZSTD_LIBRARIES "libzstd_static" CACHE INTERNAL "" FORCE)
+endif()
+
+
 # minizip-ng
 if(NOT TARGET MINIZIP::minizip)
     set(MZ_COMPAT           OFF CACHE INTERNAL "" FORCE)
-    set(MZ_ZLIB             ON  CACHE INTERNAL "")
-    set(MZ_BZIP2            ON  CACHE INTERNAL "")
-    set(MZ_LZMA             ON  CACHE INTERNAL "")
-    set(MZ_ZSTD             ON  CACHE INTERNAL "")
-    set(MZ_LIBCOMP          OFF CACHE INTERNAL "")
+    set(MZ_FETCH_LIBS       ON  CACHE INTERNAL "")
+    set(MZ_FORCE_FETCH_LIBS OFF CACHE INTERNAL "")
     set(MZ_PKCRYPT          OFF CACHE INTERNAL "")
     set(MZ_WZAES            OFF CACHE INTERNAL "")
     set(MZ_OPENSSL          OFF CACHE INTERNAL "")
-    set(MZ_FETCH_LIBS       ON  CACHE INTERNAL "")
-    set(MZ_FORCE_FETCH_LIBS ON  CACHE INTERNAL "")
     set(SKIP_INSTALL_ALL    ON  CACHE INTERNAL "" FORCE)
     add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/minizip-ng")
 

--- a/include/vpkpp/Options.h
+++ b/include/vpkpp/Options.h
@@ -20,8 +20,8 @@ struct BakeOptions {
 	/// BSP/ZIP - Override compression type of all stored entries
 	EntryCompressionType zip_compressionTypeOverride = EntryCompressionType::NO_OVERRIDE;
 
-	/// BSP/ZIP - Compression strength (use -1 for the compression type's default)
-	int8_t zip_compressionStrength = -1;
+	/// BSP/VPK/ZIP - Compression strength
+	int8_t zip_compressionStrength = 0;
 
 	/// GMA - Write CRCs for files and the overall GMA file when baking
 	bool gma_writeCRCs = true;

--- a/include/vpkpp/format/VPK.h
+++ b/include/vpkpp/format/VPK.h
@@ -129,6 +129,10 @@ protected:
 
 	void addEntryInternal(Entry& entry, const std::string& path, std::vector<std::byte>& buffer, EntryOptions options) override;
 
+	[[nodiscard]] bool hasExtendedHeader() const;
+
+	[[nodiscard]] bool hasCompression() const;
+
 	[[nodiscard]] uint32_t getHeaderLength() const;
 
 	uint32_t numArchives = -1;

--- a/src/vpkpp/_vpkpp.cmake
+++ b/src/vpkpp/_vpkpp.cmake
@@ -1,5 +1,5 @@
 add_pretty_parser(vpkpp
-        DEPS cryptopp::cryptopp MINIZIP::minizip sourcepp::bsppp sourcepp::kvpp
+        DEPS cryptopp::cryptopp libzstd_static MINIZIP::minizip sourcepp::bsppp sourcepp::kvpp
         DEPS_INTERFACE tsl::hat_trie
         PRECOMPILED_HEADERS
         "${CMAKE_CURRENT_SOURCE_DIR}/include/vpkpp/format/BSP.h"


### PR DESCRIPTION
v54 adds a compressed length field (`uint32_t`) after the length field for each entry and before the entry terminator. If the compressed length is 0, the file is not compressed. Compression is done through zstd, and the compression dictionary is saved inside the VPK as a regular file named after the VPK filename (i.e. a VPK named `cstrike_dir.vpk` would have a file called `cstrike.dict` at the root of the VPK).