### PR TITLE
fix: Compilation issue on Clang while using GCC's C++ standard library

### DIFF
--- a/src/vtfpp/VTF.cpp
+++ b/src/vtfpp/VTF.cpp
@@ -1,6 +1,7 @@
 #include <vtfpp/VTF.h>
 
 #include <cstring>
+#include <algorithm>
 #include <unordered_map>
 
 #include <BufferStream.h>


### PR DESCRIPTION
the usage of algorithms "pre" included by other headers causes issues on platforms on which they aren't explicitly included.