### PR TITLE
fix(bsppp): add algorithm to fix missing sort

### DIFF
--- a/src/bsppp/bsppp.cpp
+++ b/src/bsppp/bsppp.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <type_traits>
 #include <utility>
+#include <algorithm>
 
 #include <FileStream.h>
 


### PR DESCRIPTION
`src/bsppp/bsppp.cpp` is missing an `#include <algorithm>`

Compiling vpkedit head results in this error without it:
```
/home/hurricane/aur/vpkedit-git/src/vpkedit-git/src/shared/thirdparty/sourcepp/src/bsppp/bsppp.cpp:178:8: error: no member named 'sort' in namespace 'std'
  178 |                 std::sort(lumpIDs.begin(), lumpIDs.end(), [this](int lhs, int rhs) {
      |                 ~~~~~^
1 error generated.
```