### PR TITLE
vtfpp: VTFX (X360, PS3) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ Several modern C++20 libraries for sanely parsing Valve formats, rolled into one
   </tr>
   <tr><!-- empty row to disable github striped bg color --></tr>
   <tr>
-    <td rowspan="27"><code>vtfpp</code></td>
+    <td rowspan="29"><code>vtfpp</code></td>
     <td><a href="https://wiki.mozilla.org/APNG_Specification">APNG</a></td>
     <td align="center">✅</td>
     <td align="center">❌</td>
-    <td rowspan="27" align="center">Python</td>
+    <td rowspan="29" align="center">Python</td>
   </tr>
   <tr><!-- empty row to disable github striped bg color --></tr>
   <tr>
@@ -320,6 +320,14 @@ Several modern C++20 libraries for sanely parsing Valve formats, rolled into one
     <td>
       <a href="https://developer.valvesoftware.com/wiki/VTF_(Valve_Texture_Format)">VTF</a> v7.0-7.6
       <br> &bull; <a href="https://stratasource.org">Strata Source</a> modifications
+    </td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr><!-- empty row to disable github striped bg color --></tr>
+  <tr>
+    <td>
+      <a href="https://developer.valvesoftware.com/wiki/VTFX_file_format">VTFX</a> (X360, PS3)
     </td>
     <td align="center">✅</td>
     <td align="center">✅</td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -207,11 +207,11 @@ Several modern C++20 libraries for sanely parsing Valve formats, rolled into one
     <td align="center">✅</td>
   </tr>
   <tr>
-    <td rowspan="14"><code>vtfpp</code></td>
+    <td rowspan="15"><code>vtfpp</code></td>
     <td><a href="https://wiki.mozilla.org/APNG_Specification">APNG</a></td>
     <td align="center">✅</td>
     <td align="center">❌</td>
-    <td rowspan="14" align="center">Python</td>
+    <td rowspan="15" align="center">Python</td>
   </tr>
   <tr>
     <td><a href="https://en.wikipedia.org/wiki/BMP_file_format">BMP</a></td>
@@ -277,6 +277,13 @@ Several modern C++20 libraries for sanely parsing Valve formats, rolled into one
     <td>
       <a href="https://developer.valvesoftware.com/wiki/VTF_(Valve_Texture_Format)">VTF</a> v7.0-7.6
       <br> &bull; <a href="https://stratasource.org">Strata Source</a> modifications
+    </td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://developer.valvesoftware.com/wiki/VTFX_file_format">VTFX</a> (X360, PS3)
     </td>
     <td align="center">✅</td>
     <td align="center">✅</td>

--- a/include/vtfpp/ImageConversion.h
+++ b/include/vtfpp/ImageConversion.h
@@ -18,14 +18,19 @@ namespace ImagePixel {
 #define VTFPP_CHECK_SIZE(format) \
 	static_assert(sizeof(format) == ImageFormatDetails::bpp(ImageFormat::format) / 8)
 
+#define VTFPP_FORMAT_INHERITED(format, parent)              \
+	struct format : parent {                                \
+        static constexpr auto FORMAT = ImageFormat::format; \
+	};                                                      \
+	VTFPP_CHECK_SIZE(format)
+
 struct RGBA8888 {
 	static constexpr auto FORMAT = ImageFormat::RGBA8888;
 	uint8_t r;
 	uint8_t g;
 	uint8_t b;
 	uint8_t a;
-};
-VTFPP_CHECK_SIZE(RGBA8888);
+}; VTFPP_CHECK_SIZE(RGBA8888);
 
 struct ABGR8888 {
 	static constexpr auto FORMAT = ImageFormat::ABGR8888;
@@ -33,67 +38,53 @@ struct ABGR8888 {
 	uint8_t b;
 	uint8_t g;
 	uint8_t r;
-};
-VTFPP_CHECK_SIZE(ABGR8888);
+}; VTFPP_CHECK_SIZE(ABGR8888);
 
 struct RGB888 {
 	static constexpr auto FORMAT = ImageFormat::RGB888;
 	uint8_t r;
 	uint8_t g;
 	uint8_t b;
-};
-VTFPP_CHECK_SIZE(RGB888);
+}; VTFPP_CHECK_SIZE(RGB888);
 
-struct RGB888_BLUESCREEN : RGB888 {
-	static constexpr auto FORMAT = ImageFormat::RGB888_BLUESCREEN;
-};
-VTFPP_CHECK_SIZE(RGB888_BLUESCREEN);
+VTFPP_FORMAT_INHERITED(RGB888_BLUESCREEN, RGB888);
 
 struct BGR888 {
 	static constexpr auto FORMAT = ImageFormat::BGR888;
 	uint8_t b;
 	uint8_t g;
 	uint8_t r;
-};
-VTFPP_CHECK_SIZE(BGR888);
+}; VTFPP_CHECK_SIZE(BGR888);
 
-struct BGR888_BLUESCREEN : BGR888 {
-	static constexpr auto FORMAT = ImageFormat::BGR888_BLUESCREEN;
-};
-VTFPP_CHECK_SIZE(BGR888_BLUESCREEN);
+VTFPP_FORMAT_INHERITED(BGR888_BLUESCREEN, BGR888);
 
 struct RGB565 {
 	static constexpr auto FORMAT = ImageFormat::RGB565;
 	uint16_t r : 5;
 	uint16_t g : 6;
 	uint16_t b : 5;
-};
-VTFPP_CHECK_SIZE(RGB565);
+}; VTFPP_CHECK_SIZE(RGB565);
 
 struct I8 {
 	static constexpr auto FORMAT = ImageFormat::I8;
 	uint8_t i;
-};
-VTFPP_CHECK_SIZE(I8);
+}; VTFPP_CHECK_SIZE(I8);
 
 struct IA88 {
 	static constexpr auto FORMAT = ImageFormat::IA88;
 	uint8_t i;
 	uint8_t a;
-};
-VTFPP_CHECK_SIZE(IA88);
+}; VTFPP_CHECK_SIZE(IA88);
 
 struct P8 {
 	static constexpr auto FORMAT = ImageFormat::P8;
 	uint8_t p;
-};
-VTFPP_CHECK_SIZE(P8);
+}; VTFPP_CHECK_SIZE(P8);
 
 struct A8 {
 	static constexpr auto FORMAT = ImageFormat::A8;
 	uint8_t a;
-};
-VTFPP_CHECK_SIZE(A8);
+}; VTFPP_CHECK_SIZE(A8);
 
 struct ARGB8888 {
 	static constexpr auto FORMAT = ImageFormat::ARGB8888;
@@ -101,8 +92,7 @@ struct ARGB8888 {
 	uint8_t r;
 	uint8_t g;
 	uint8_t b;
-};
-VTFPP_CHECK_SIZE(ARGB8888);
+}; VTFPP_CHECK_SIZE(ARGB8888);
 
 struct BGRA8888 {
 	static constexpr auto FORMAT = ImageFormat::BGRA8888;
@@ -110,8 +100,7 @@ struct BGRA8888 {
 	uint8_t g;
 	uint8_t r;
 	uint8_t a;
-};
-VTFPP_CHECK_SIZE(BGRA8888);
+}; VTFPP_CHECK_SIZE(BGRA8888);
 
 struct BGRX8888 {
 	static constexpr auto FORMAT = ImageFormat::BGRX8888;
@@ -119,16 +108,14 @@ struct BGRX8888 {
 	uint8_t g;
 	uint8_t r;
 	uint8_t x;
-};
-VTFPP_CHECK_SIZE(BGRX8888);
+}; VTFPP_CHECK_SIZE(BGRX8888);
 
 struct BGR565 {
 	static constexpr auto FORMAT = ImageFormat::BGR565;
 	uint16_t b : 5;
 	uint16_t g : 6;
 	uint16_t r : 5;
-};
-VTFPP_CHECK_SIZE(BGR565);
+}; VTFPP_CHECK_SIZE(BGR565);
 
 struct BGRX5551 {
 	static constexpr auto FORMAT = ImageFormat::BGRX5551;
@@ -136,8 +123,7 @@ struct BGRX5551 {
 	uint16_t g : 5;
 	uint16_t r : 5;
 	uint16_t x : 1;
-};
-VTFPP_CHECK_SIZE(BGRX5551);
+}; VTFPP_CHECK_SIZE(BGRX5551);
 
 struct BGRA4444 {
 	static constexpr auto FORMAT = ImageFormat::BGRA4444;
@@ -145,8 +131,7 @@ struct BGRA4444 {
 	uint16_t g : 4;
 	uint16_t r : 4;
 	uint16_t a : 4;
-};
-VTFPP_CHECK_SIZE(BGRA4444);
+}; VTFPP_CHECK_SIZE(BGRA4444);
 
 struct BGRA5551 {
 	static constexpr auto FORMAT = ImageFormat::BGRA5551;
@@ -154,15 +139,13 @@ struct BGRA5551 {
 	uint16_t g : 5;
 	uint16_t r : 5;
 	uint16_t a : 1;
-};
-VTFPP_CHECK_SIZE(BGRA5551);
+}; VTFPP_CHECK_SIZE(BGRA5551);
 
 struct UV88 {
 	static constexpr auto FORMAT = ImageFormat::UV88;
 	uint8_t u;
 	uint8_t v;
-};
-VTFPP_CHECK_SIZE(UV88);
+}; VTFPP_CHECK_SIZE(UV88);
 
 struct UVWQ8888 {
 	static constexpr auto FORMAT = ImageFormat::UVWQ8888;
@@ -170,8 +153,7 @@ struct UVWQ8888 {
 	uint8_t v;
 	uint8_t w;
 	uint8_t q;
-};
-VTFPP_CHECK_SIZE(UVWQ8888);
+}; VTFPP_CHECK_SIZE(UVWQ8888);
 
 struct RGBA16161616F {
 	static constexpr auto FORMAT = ImageFormat::RGBA16161616F;
@@ -179,8 +161,7 @@ struct RGBA16161616F {
 	half g;
 	half b;
 	half a;
-};
-VTFPP_CHECK_SIZE(RGBA16161616F);
+}; VTFPP_CHECK_SIZE(RGBA16161616F);
 
 struct RGBA16161616 {
 	static constexpr auto FORMAT = ImageFormat::RGBA16161616;
@@ -188,8 +169,7 @@ struct RGBA16161616 {
 	uint16_t g;
 	uint16_t b;
 	uint16_t a;
-};
-VTFPP_CHECK_SIZE(RGBA16161616);
+}; VTFPP_CHECK_SIZE(RGBA16161616);
 
 struct UVLX8888 {
 	static constexpr auto FORMAT = ImageFormat::UVLX8888;
@@ -197,22 +177,19 @@ struct UVLX8888 {
 	uint8_t v;
 	uint8_t l;
 	uint8_t x;
-};
-VTFPP_CHECK_SIZE(UVLX8888);
+}; VTFPP_CHECK_SIZE(UVLX8888);
 
 struct R32F {
 	static constexpr auto FORMAT = ImageFormat::R32F;
 	float r;
-};
-VTFPP_CHECK_SIZE(R32F);
+}; VTFPP_CHECK_SIZE(R32F);
 
 struct RGB323232F {
 	static constexpr auto FORMAT = ImageFormat::R32F;
 	float r;
 	float g;
 	float b;
-};
-VTFPP_CHECK_SIZE(RGB323232F);
+}; VTFPP_CHECK_SIZE(RGB323232F);
 
 struct RGBA32323232F {
 	static constexpr auto FORMAT = ImageFormat::RGBA32323232F;
@@ -220,22 +197,19 @@ struct RGBA32323232F {
 	float g;
 	float b;
 	float a;
-};
-VTFPP_CHECK_SIZE(RGBA32323232F);
+}; VTFPP_CHECK_SIZE(RGBA32323232F);
 
 struct RG1616F {
 	static constexpr auto FORMAT = ImageFormat::RG1616F;
 	half r;
 	half g;
-};
-VTFPP_CHECK_SIZE(RG1616F);
+}; VTFPP_CHECK_SIZE(RG1616F);
 
 struct RG3232F {
 	static constexpr auto FORMAT = ImageFormat::RG3232F;
 	float r;
 	float g;
-};
-VTFPP_CHECK_SIZE(RG3232F);
+}; VTFPP_CHECK_SIZE(RG3232F);
 
 struct RGBX8888 {
 	static constexpr auto FORMAT = ImageFormat::RGBX8888;
@@ -243,8 +217,7 @@ struct RGBX8888 {
 	uint8_t g;
 	uint8_t b;
 	uint8_t x;
-};
-VTFPP_CHECK_SIZE(RGBX8888);
+}; VTFPP_CHECK_SIZE(RGBX8888);
 
 struct RGBA1010102 {
 	static constexpr auto FORMAT = ImageFormat::RGBA1010102;
@@ -252,8 +225,7 @@ struct RGBA1010102 {
 	uint32_t g : 10;
 	uint32_t b : 10;
 	uint32_t a : 2;
-};
-VTFPP_CHECK_SIZE(RGBA1010102);
+}; VTFPP_CHECK_SIZE(RGBA1010102);
 
 struct BGRA1010102 {
 	static constexpr auto FORMAT = ImageFormat::BGRA1010102;
@@ -261,21 +233,43 @@ struct BGRA1010102 {
 	uint32_t g : 10;
 	uint32_t r : 10;
 	uint32_t a : 2;
-};
-VTFPP_CHECK_SIZE(BGRA1010102);
+}; VTFPP_CHECK_SIZE(BGRA1010102);
 
 struct R16F {
 	static constexpr auto FORMAT = ImageFormat::R16F;
 	half r;
-};
-VTFPP_CHECK_SIZE(R16F);
+}; VTFPP_CHECK_SIZE(R16F);
 
 struct R8 {
 	static constexpr auto FORMAT = ImageFormat::R8;
 	uint8_t r;
-};
-VTFPP_CHECK_SIZE(R8);
+}; VTFPP_CHECK_SIZE(R8);
 
+VTFPP_FORMAT_INHERITED(CONSOLE_BGRX8888_LINEAR, BGRX8888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_RGBA8888_LINEAR, RGBA8888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_ABGR8888_LINEAR, ABGR8888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_ARGB8888_LINEAR, ARGB8888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_BGRA8888_LINEAR, BGRA8888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_RGB888_LINEAR, RGB888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_BGR888_LINEAR, BGR888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_BGRX5551_LINEAR, BGRX5551);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_I8_LINEAR, I8);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_RGBA16161616_LINEAR, RGBA16161616);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_BGRX8888_LE, BGRX8888);
+
+VTFPP_FORMAT_INHERITED(CONSOLE_BGRA8888_LE, BGRA8888);
+
+#undef VTFPP_FORMAT_INHERITED
 #undef VTFPP_CHECK_SIZE
 
 template<typename T>
@@ -312,6 +306,18 @@ concept PixelType =
 		std::same_as<T, RGBA1010102> ||
 		std::same_as<T, BGRA1010102> ||
 		std::same_as<T, R16F> ||
+		std::same_as<T, CONSOLE_BGRX8888_LINEAR> ||
+		std::same_as<T, CONSOLE_RGBA8888_LINEAR> ||
+		std::same_as<T, CONSOLE_ABGR8888_LINEAR> ||
+		std::same_as<T, CONSOLE_ARGB8888_LINEAR> ||
+		std::same_as<T, CONSOLE_BGRA8888_LINEAR> ||
+		std::same_as<T, CONSOLE_RGB888_LINEAR> ||
+		std::same_as<T, CONSOLE_BGR888_LINEAR> ||
+		std::same_as<T, CONSOLE_BGRX5551_LINEAR> ||
+		std::same_as<T, CONSOLE_I8_LINEAR> ||
+		std::same_as<T, CONSOLE_RGBA16161616_LINEAR> ||
+		std::same_as<T, CONSOLE_BGRX8888_LE> ||
+		std::same_as<T, CONSOLE_BGRA8888_LE> ||
 		std::same_as<T, R8>;
 
 } // namespace ImagePixel

--- a/include/vtfpp/ImageFormats.h
+++ b/include/vtfpp/ImageFormats.h
@@ -5,6 +5,7 @@
 namespace vtfpp {
 
 enum class ImageFormat : int32_t {
+	// region Universal Formats
 	RGBA8888 = 0,
 	ABGR8888,
 	RGB888,
@@ -35,6 +36,9 @@ enum class ImageFormat : int32_t {
 	R32F,
 	RGB323232F,
 	RGBA32323232F,
+	// endregion
+
+	// region Alien Swarm & Beyond Formats
 	RG1616F,
 	RG3232F,
 	RGBX8888,
@@ -44,10 +48,28 @@ enum class ImageFormat : int32_t {
 	RGBA1010102,
 	BGRA1010102,
 	R16F,
+	// endregion
 
+	// region Console Formats
+	CONSOLE_BGRX8888_LINEAR = 42,
+	CONSOLE_RGBA8888_LINEAR,
+	CONSOLE_ABGR8888_LINEAR,
+	CONSOLE_ARGB8888_LINEAR,
+	CONSOLE_BGRA8888_LINEAR,
+	CONSOLE_RGB888_LINEAR,
+	CONSOLE_BGR888_LINEAR,
+	CONSOLE_BGRX5551_LINEAR,
+	CONSOLE_I8_LINEAR,
+	CONSOLE_RGBA16161616_LINEAR,
+	CONSOLE_BGRX8888_LE,
+	CONSOLE_BGRA8888_LE,
+	// endregion
+
+	// region Strata Source Formats
 	R8 = 69,
 	BC7,
 	BC6H,
+	// endregion
 };
 
 namespace ImageFormatDetails {
@@ -64,22 +86,33 @@ namespace ImageFormatDetails {
 		case RG1616F:
 		case RGBA16161616F:
 		case RGBA16161616:
+		case CONSOLE_RGBA16161616_LINEAR:
 			return 16;
 		case RGBA1010102:
 		case BGRA1010102:
 			return 10;
 		case RGBA8888:
+		case CONSOLE_RGBA8888_LINEAR:
 		case ABGR8888:
+		case CONSOLE_ABGR8888_LINEAR:
 		case RGB888:
+		case CONSOLE_RGB888_LINEAR:
 		case BGR888:
+		case CONSOLE_BGR888_LINEAR:
 		case I8:
+		case CONSOLE_I8_LINEAR:
 		case IA88:
 		case P8:
 		case RGB888_BLUESCREEN:
 		case BGR888_BLUESCREEN:
 		case ARGB8888:
+		case CONSOLE_ARGB8888_LINEAR:
 		case BGRA8888:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_BGRA8888_LE:
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case UV88:
 		case UVWQ8888:
 		case UVLX8888:
@@ -89,6 +122,7 @@ namespace ImageFormatDetails {
 		case RGB565:
 		case BGR565:
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case BGRA5551:
 			return 5;
 		case BGRA4444:
@@ -139,19 +173,29 @@ namespace ImageFormatDetails {
 		case RG1616F:
 		case RGBA16161616F:
 		case RGBA16161616:
+		case CONSOLE_RGBA16161616_LINEAR:
 			return 16;
 		case RGBA1010102:
 		case BGRA1010102:
 			return 10;
 		case RGBA8888:
+		case CONSOLE_RGBA8888_LINEAR:
 		case ABGR8888:
+		case CONSOLE_ABGR8888_LINEAR:
 		case RGB888:
+		case CONSOLE_RGB888_LINEAR:
 		case BGR888:
+		case CONSOLE_BGR888_LINEAR:
 		case RGB888_BLUESCREEN:
 		case BGR888_BLUESCREEN:
 		case ARGB8888:
+		case CONSOLE_ARGB8888_LINEAR:
 		case BGRA8888:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_BGRA8888_LE:
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case UV88:
 		case UVWQ8888:
 		case UVLX8888:
@@ -161,11 +205,13 @@ namespace ImageFormatDetails {
 		case BGR565:
 			return 6;
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case BGRA5551:
 			return 5;
 		case BGRA4444:
 			return 4;
 		case I8:
+		case CONSOLE_I8_LINEAR:
 		case IA88:
 		case P8:
 		case R32F:
@@ -215,19 +261,29 @@ namespace ImageFormatDetails {
 			return 32;
 		case RGBA16161616F:
 		case RGBA16161616:
+		case CONSOLE_RGBA16161616_LINEAR:
 			return 16;
 		case RGBA1010102:
 		case BGRA1010102:
 			return 10;
 		case RGBA8888:
+		case CONSOLE_RGBA8888_LINEAR:
 		case ABGR8888:
+		case CONSOLE_ABGR8888_LINEAR:
 		case RGB888:
+		case CONSOLE_RGB888_LINEAR:
 		case BGR888:
+		case CONSOLE_BGR888_LINEAR:
 		case RGB888_BLUESCREEN:
 		case BGR888_BLUESCREEN:
 		case ARGB8888:
+		case CONSOLE_ARGB8888_LINEAR:
 		case BGRA8888:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_BGRA8888_LE:
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case UVWQ8888:
 		case UVLX8888:
 		case RGBX8888:
@@ -235,11 +291,13 @@ namespace ImageFormatDetails {
 		case RGB565:
 		case BGR565:
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case BGRA5551:
 			return 5;
 		case BGRA4444:
 			return 4;
 		case I8:
+		case CONSOLE_I8_LINEAR:
 		case IA88:
 		case P8:
 		case UV88:
@@ -291,13 +349,21 @@ namespace ImageFormatDetails {
 			return 32;
 		case RGBA16161616F:
 		case RGBA16161616:
+		case CONSOLE_RGBA16161616_LINEAR:
 			return 16;
 		case RGBA8888:
+		case CONSOLE_RGBA8888_LINEAR:
 		case ABGR8888:
+		case CONSOLE_ABGR8888_LINEAR:
 		case IA88:
 		case ARGB8888:
+		case CONSOLE_ARGB8888_LINEAR:
 		case BGRA8888:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_BGRA8888_LE:
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case UVWQ8888:
 		case UVLX8888:
 		case RGBX8888:
@@ -308,12 +374,16 @@ namespace ImageFormatDetails {
 		case BGRA1010102:
 			return 2;
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case BGRA5551:
 			return 1;
 		case RGB888:
+		case CONSOLE_RGB888_LINEAR:
 		case BGR888:
+		case CONSOLE_BGR888_LINEAR:
 		case P8:
 		case I8:
+		case CONSOLE_I8_LINEAR:
 		case RGB888_BLUESCREEN:
 		case BGR888_BLUESCREEN:
 		case UV88:
@@ -372,13 +442,21 @@ namespace ImageFormatDetails {
 			return 96;
 		case RGBA16161616F:
 		case RGBA16161616:
+		case CONSOLE_RGBA16161616_LINEAR:
 		case RG3232F:
 			return 64;
 		case RGBA8888:
+		case CONSOLE_RGBA8888_LINEAR:
 		case ABGR8888:
+		case CONSOLE_ABGR8888_LINEAR:
 		case ARGB8888:
+		case CONSOLE_ARGB8888_LINEAR:
 		case BGRA8888:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_BGRA8888_LE:
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case UVLX8888:
 		case R32F:
 		case UVWQ8888:
@@ -388,7 +466,9 @@ namespace ImageFormatDetails {
 		case RG1616F:
 			return 32;
 		case RGB888:
+		case CONSOLE_RGB888_LINEAR:
 		case BGR888:
+		case CONSOLE_BGR888_LINEAR:
 		case RGB888_BLUESCREEN:
 		case BGR888_BLUESCREEN:
 			return 24;
@@ -396,12 +476,14 @@ namespace ImageFormatDetails {
 		case BGR565:
 		case IA88:
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case BGRA4444:
 		case BGRA5551:
 		case UV88:
 		case R16F:
 			return 16;
 		case I8:
+		case CONSOLE_I8_LINEAR:
 		case P8:
 		case A8:
 		case DXT3:
@@ -434,26 +516,38 @@ namespace ImageFormatDetails {
 		case BC6H:
 			return RGBA32323232F;
 		case RGBA16161616:
+		case CONSOLE_RGBA16161616_LINEAR:
 		case RGBA1010102:
 		case BGRA1010102:
 			return RGBA16161616;
 		case RGBA8888:
+		case CONSOLE_RGBA8888_LINEAR:
 		case ABGR8888:
+		case CONSOLE_ABGR8888_LINEAR:
 		case RGB888:
+		case CONSOLE_RGB888_LINEAR:
 		case BGR888:
+		case CONSOLE_BGR888_LINEAR:
 		case RGB888_BLUESCREEN:
 		case BGR888_BLUESCREEN:
 		case ARGB8888:
+		case CONSOLE_ARGB8888_LINEAR:
 		case BGRA8888:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_BGRA8888_LE:
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case UVWQ8888:
 		case UVLX8888:
 		case RGB565:
 		case BGR565:
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case BGRA5551:
 		case BGRA4444:
 		case I8:
+		case CONSOLE_I8_LINEAR:
 		case IA88:
 		case P8:
 		case UV88:
@@ -510,7 +604,10 @@ namespace ImageFormatDetails {
 		case BGR888_BLUESCREEN:
 			return true;
 		case BGRX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_BGRX8888_LE:
 		case BGRX5551:
+		case CONSOLE_BGRX5551_LINEAR:
 		case UVLX8888:
 		case RGBX8888:
 			return false;
@@ -561,6 +658,28 @@ namespace ImageDimensions {
 		}
 	}
 	return maxMipCount;
+}
+
+[[nodiscard]] constexpr uint8_t getActualMipCountForDimsOnConsole(uint16_t width, uint16_t height) {
+	if (width == 0 || height == 0) {
+		return 0;
+	}
+	uint8_t numMipLevels = 1;
+	while (true) {
+		if (width == 1 && height == 1) {
+			break;
+		}
+		width >>= 1;
+		if (width < 1) {
+			width = 1;
+		}
+		height >>= 1;
+		if (height < 1) {
+			height = 1;
+		}
+		numMipLevels += 1;
+	}
+	return numMipLevels;
 }
 
 } // namespace ImageDimensions

--- a/include/vtfpp/VTF.h
+++ b/include/vtfpp/VTF.h
@@ -182,9 +182,9 @@ public:
 		bool isCubeMap = false;
 		bool hasSphereMap = false;
 		uint16_t initialSliceCount = 1;
-		bool createMips = true;
-		bool createThumbnail = true;
-		bool createReflectivity = true;
+		bool computeMips = true;
+		bool computeThumbnail = true;
+		bool computeReflectivity = true;
 		Platform platform = PLATFORM_PC;
 		int16_t compressionLevel = -1;
 		CompressionMethod compressionMethod = CompressionMethod::ZSTD;

--- a/lang/python/src/vtfpp.h
+++ b/lang/python/src/vtfpp.h
@@ -388,9 +388,9 @@ void register_python(py::module_& m) {
 		.def_rw("is_cubemap",           &VTF::CreationOptions::isCubeMap)
 		.def_rw("has_spheremap",        &VTF::CreationOptions::hasSphereMap)
 		.def_rw("initial_slice_count",  &VTF::CreationOptions::initialSliceCount)
-		.def_rw("create_mips",          &VTF::CreationOptions::createMips)
-		.def_rw("create_thumbnail",     &VTF::CreationOptions::createThumbnail)
-		.def_rw("create_reflectivity",  &VTF::CreationOptions::createReflectivity)
+		.def_rw("compute_mips",         &VTF::CreationOptions::computeMips)
+		.def_rw("compute_thumbnail",    &VTF::CreationOptions::computeThumbnail)
+		.def_rw("compute_reflectivity", &VTF::CreationOptions::computeReflectivity)
 		.def_rw("compression_level",    &VTF::CreationOptions::compressionLevel)
 		.def_rw("compression_method",   &VTF::CreationOptions::compressionMethod)
 		.def_rw("bumpmap_scale",        &VTF::CreationOptions::bumpMapScale);

--- a/lang/python/src/vtfpp.h
+++ b/lang/python/src/vtfpp.h
@@ -367,6 +367,13 @@ void register_python(py::module_& m) {
 		.value("SPECVAR_ALPHA",                           VTF::FLAG_SPECVAR_ALPHA)
 		.export_values();
 
+	py::enum_<VTF::Platform>(cVTF, "Platform")
+		.value("UNKNOWN", VTF::PLATFORM_UNKNOWN)
+		.value("PC",      VTF::PLATFORM_PC)
+		.value("PS3",     VTF::PLATFORM_PS3)
+		.value("X360",    VTF::PLATFORM_X360)
+		.export_values();
+
 	py::class_<VTF::CreationOptions>(cVTF, "CreationOptions")
 		.def(py::init<>())
 		.def_rw("major_version",        &VTF::CreationOptions::majorVersion)
@@ -392,7 +399,6 @@ void register_python(py::module_& m) {
 		.def_ro_static("FLAG_MASK_GENERATED", &VTF::FLAG_MASK_GENERATED)
 		.def_ro_static("FORMAT_UNCHANGED",    &VTF::FORMAT_UNCHANGED)
 		.def_ro_static("FORMAT_DEFAULT",      &VTF::FORMAT_DEFAULT)
-		.def_ro_static("MAX_RESOURCES",       &VTF::MAX_RESOURCES)
 		.def(py::init<>())
 		.def("__init__", [](VTF* self, const py::bytes& vtfData, bool parseHeaderOnly = false) {
 			return new(self) VTF{std::span{reinterpret_cast<const std::byte*>(vtfData.data()), vtfData.size()}, parseHeaderOnly};
@@ -409,6 +415,7 @@ void register_python(py::module_& m) {
 		.def_static("create_blank", py::overload_cast<ImageFormat, uint16_t, uint16_t, VTF::CreationOptions>(&VTF::create), py::arg("format"), py::arg("width"), py::arg("height"), py::arg("creation_options") = VTF::CreationOptions{})
 		.def_static("create_from_file_and_bake", py::overload_cast<const std::string&, const std::string&, VTF::CreationOptions>(&VTF::create), py::arg("image_path"), py::arg("vtf_path"), py::arg("creation_options") = VTF::CreationOptions{})
 		.def_static("create_from_file", py::overload_cast<const std::string&, VTF::CreationOptions>(&VTF::create), py::arg("image_path"), py::arg("creation_options") = VTF::CreationOptions{})
+		.def_prop_rw("platform", &VTF::getPlatform, &VTF::setPlatform)
 		.def_prop_rw("version_major", &VTF::getMajorVersion, &VTF::setMajorVersion)
 		.def_prop_rw("version_minor", &VTF::getMinorVersion, &VTF::setMinorVersion)
 		.def_prop_rw("image_width_resize_method", &VTF::getImageWidthResizeMethod, &VTF::setImageWidthResizeMethod)

--- a/src/sourcepp/compression/LZMA.cpp
+++ b/src/sourcepp/compression/LZMA.cpp
@@ -6,54 +6,45 @@
 using namespace sourcepp;
 
 std::optional<std::vector<std::byte>> compression::compressValveLZMA(std::span<const std::byte> data, uint8_t compressLevel) {
-	// Preallocate extra 4 bytes for Valve LZMA header signature
-	std::vector<std::byte> compressedData(sizeof(uint32_t));
-	std::array<std::byte, 8192> compressedChunk{};
-
-	lzma_stream stream{
-		.next_in = reinterpret_cast<const uint8_t*>(data.data()),
-		.avail_in = data.size(),
-		.next_out = reinterpret_cast<uint8_t*>(compressedChunk.data()),
-		.avail_out = compressedChunk.size(),
-	};
+	// Shift over 4 bytes for Valve LZMA header signature
+	std::vector<std::byte> compressedData(sizeof(uint32_t) + data.size() * 2);
 
 	lzma_options_lzma options{};
-	lzma_lzma_preset(&options, std::clamp<uint8_t>(compressLevel, 0, 9));
+	if (lzma_lzma_preset(&options, std::clamp<uint8_t>(compressLevel, 0, 9))) {
+		return std::nullopt;
+	}
+
+	lzma_stream stream = LZMA_STREAM_INIT;
 
 	if (lzma_alone_encoder(&stream, &options) != LZMA_OK) {
 		lzma_end(&stream);
 		return std::nullopt;
 	}
 
-	lzma_ret ret;
-	do {
-		stream.next_out = reinterpret_cast<uint8_t*>(compressedChunk.data());
-		stream.avail_out = compressedChunk.size();
+	stream.next_in = reinterpret_cast<const uint8_t*>(data.data());
+	stream.avail_in = data.size();
+	stream.next_out = reinterpret_cast<uint8_t*>(compressedData.data() + sizeof(uint32_t));
+	stream.avail_out = compressedData.size() - sizeof(uint32_t);
 
-		ret = lzma_code(&stream, LZMA_RUN);
-		compressedData.insert(compressedData.end(), compressedChunk.begin(), compressedChunk.begin() + compressedChunk.size() - static_cast<std::ptrdiff_t>(stream.avail_out));
-	} while (ret == LZMA_OK);
-
-	ret = lzma_code(&stream, LZMA_FINISH);
-	if (ret != LZMA_OK && ret != LZMA_STREAM_END) {
-		lzma_end(&stream);
+	lzma_ret ret = lzma_code(&stream, LZMA_FINISH);
+	lzma_end(&stream);
+	if (ret != LZMA_STREAM_END) {
 		return std::nullopt;
 	}
-	lzma_end(&stream);
 
-	{
-		// Switch out normal header with Valve one
-		BufferStream compressedStream{compressedData};
-		compressedStream << VALVE_LZMA_SIGNATURE;
-		const auto properties = compressedStream.read<uint8_t>();
-		const auto dictionarySize = compressedStream.read<uint32_t>();
-		compressedStream
-			.seek_u(sizeof(uint32_t))
-			.write<uint32_t>(data.size())
-			.write(compressedData.size() - (sizeof(uint32_t) * 3) + (sizeof(uint8_t) * 5))
-			.write(properties)
-			.write(dictionarySize);
-	}
+	// Switch out normal header with Valve one
+	BufferStream compressedStream{compressedData};
+	compressedStream.seek(0).write(VALVE_LZMA_SIGNATURE);
+	const auto properties = compressedStream.read<uint8_t>();
+	const auto dictionarySize = compressedStream.read<uint32_t>();
+	compressedStream
+		.seek_u(sizeof(uint32_t))
+		.write<uint32_t>(data.size())
+		.write(compressedData.size() - (sizeof(uint32_t) * 3) + (sizeof(uint8_t) * 5))
+		.write(properties)
+		.write(dictionarySize);
+
+	compressedData.resize(stream.total_out + sizeof(uint32_t));
 	return compressedData;
 }
 
@@ -84,12 +75,11 @@ std::optional<std::vector<std::byte>> compression::decompressValveLZMA(std::span
 		uncompressedData.resize(uncompressedLength);
 	}
 
-	lzma_stream stream{
-		.next_in = reinterpret_cast<const uint8_t*>(compressedData.data()),
-		.avail_in = compressedData.size(),
-		.next_out = reinterpret_cast<uint8_t*>(uncompressedData.data()),
-		.avail_out = uncompressedData.size(),
-	};
+	lzma_stream stream = LZMA_STREAM_INIT;
+	stream.next_in = reinterpret_cast<const uint8_t*>(compressedData.data());
+	stream.avail_in = compressedData.size();
+	stream.next_out = reinterpret_cast<uint8_t*>(uncompressedData.data());
+	stream.avail_out = uncompressedData.size();
 
 	if (lzma_alone_decoder(&stream, UINT64_MAX) != LZMA_OK) {
 		lzma_end(&stream);

--- a/src/vtfpp/ImageConversion.cpp
+++ b/src/vtfpp/ImageConversion.cpp
@@ -121,6 +121,18 @@ namespace {
 		case EMPTY:
 		case BGRA1010102:
 		case RGBX8888:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_RGBA8888_LINEAR:
+		case CONSOLE_ABGR8888_LINEAR:
+		case CONSOLE_ARGB8888_LINEAR:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_RGB888_LINEAR:
+		case CONSOLE_BGR888_LINEAR:
+		case CONSOLE_BGRX5551_LINEAR:
+		case CONSOLE_I8_LINEAR:
+		case CONSOLE_RGBA16161616_LINEAR:
+		case CONSOLE_BGRX8888_LE:
+		case CONSOLE_BGRA8888_LE:
 			return CMP_FORMAT_Unknown;
 	}
 	return CMP_FORMAT_Unknown;
@@ -181,6 +193,18 @@ namespace {
 		case EMPTY:
 		case RGBA1010102:
 		case BGRA1010102:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_RGBA8888_LINEAR:
+		case CONSOLE_ABGR8888_LINEAR:
+		case CONSOLE_ARGB8888_LINEAR:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_RGB888_LINEAR:
+		case CONSOLE_BGR888_LINEAR:
+		case CONSOLE_BGRX5551_LINEAR:
+		case CONSOLE_I8_LINEAR:
+		case CONSOLE_RGBA16161616_LINEAR:
+		case CONSOLE_BGRX8888_LE:
+		case CONSOLE_BGRA8888_LE:
 			break;
 	}
 	return -1;
@@ -233,6 +257,18 @@ namespace {
 		case ATI1N:
 		case RGBA1010102:
 		case BGRA1010102:
+		case CONSOLE_BGRX8888_LINEAR:
+		case CONSOLE_RGBA8888_LINEAR:
+		case CONSOLE_ABGR8888_LINEAR:
+		case CONSOLE_ARGB8888_LINEAR:
+		case CONSOLE_BGRA8888_LINEAR:
+		case CONSOLE_RGB888_LINEAR:
+		case CONSOLE_BGR888_LINEAR:
+		case CONSOLE_BGRX5551_LINEAR:
+		case CONSOLE_I8_LINEAR:
+		case CONSOLE_RGBA16161616_LINEAR:
+		case CONSOLE_BGRX8888_LE:
+		case CONSOLE_BGRA8888_LE:
 		case BC7:
 		case BC6H:
 			break;
@@ -310,27 +346,38 @@ namespace {
 
 	switch (format) {
 		using enum ImageFormat;
-		VTFPP_CASE_CONVERT_AND_BREAK(ABGR8888,          pixel.r, pixel.g, pixel.b, pixel.a);
-		VTFPP_CASE_CONVERT_AND_BREAK(RGB888,            pixel.r, pixel.g, pixel.b, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(RGB888_BLUESCREEN, pixel.r, pixel.g, pixel.b, static_cast<uint8_t>((pixel.r == 0 && pixel.g == 0 && pixel.b == 0xff) ? 0 : 0xff));
-		VTFPP_CASE_CONVERT_AND_BREAK(BGR888,            pixel.r, pixel.g, pixel.b, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(BGR888_BLUESCREEN, pixel.r, pixel.g, pixel.b, static_cast<uint8_t>((pixel.r == 0 && pixel.g == 0 && pixel.b == 0xff) ? 0 : 0xff));
-		VTFPP_CASE_CONVERT_AND_BREAK(RGB565,            VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 6), VTFPP_REMAP_TO_8(pixel.b, 5), 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(P8,                pixel.p, pixel.p, pixel.p, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(I8,                pixel.i, pixel.i, pixel.i, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(IA88,              pixel.i, pixel.i, pixel.i, pixel.a);
-		VTFPP_CASE_CONVERT_AND_BREAK(A8,                0,       0,       0,       pixel.a);
-		VTFPP_CASE_CONVERT_AND_BREAK(ARGB8888,          pixel.r, pixel.g, pixel.b, pixel.a);
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA8888,          pixel.r, pixel.g, pixel.b, pixel.a);
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRX8888,          pixel.r, pixel.g, pixel.b, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(BGR565,            VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 6), VTFPP_REMAP_TO_8(pixel.b, 5), 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA5551,          VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 5), VTFPP_REMAP_TO_8(pixel.b, 5), static_cast<uint8_t>(pixel.a * 0xff));
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRX5551,          VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 5), VTFPP_REMAP_TO_8(pixel.b, 5), 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA4444,          VTFPP_REMAP_TO_8(pixel.r, 4), VTFPP_REMAP_TO_8(pixel.g, 4), VTFPP_REMAP_TO_8(pixel.b, 4), VTFPP_REMAP_TO_8(pixel.a, 4));
-		VTFPP_CASE_CONVERT_AND_BREAK(UV88,              pixel.u, pixel.v, 0,       0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(UVLX8888,          pixel.u, pixel.v, pixel.l, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(RGBX8888,          pixel.r, pixel.g, pixel.b, 0xff);
-		VTFPP_CASE_CONVERT_AND_BREAK(R8,                pixel.r, 0,       0,       0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(ABGR8888,                pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(RGB888,                  pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(RGB888_BLUESCREEN,       pixel.r, pixel.g, pixel.b, static_cast<uint8_t>((pixel.r == 0 && pixel.g == 0 && pixel.b == 0xff) ? 0 : 0xff));
+		VTFPP_CASE_CONVERT_AND_BREAK(BGR888,                  pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(BGR888_BLUESCREEN,       pixel.r, pixel.g, pixel.b, static_cast<uint8_t>((pixel.r == 0 && pixel.g == 0 && pixel.b == 0xff) ? 0 : 0xff));
+		VTFPP_CASE_CONVERT_AND_BREAK(RGB565,                  VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 6), VTFPP_REMAP_TO_8(pixel.b, 5), 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(P8,                      pixel.p, pixel.p, pixel.p, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(I8,                      pixel.i, pixel.i, pixel.i, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(IA88,                    pixel.i, pixel.i, pixel.i, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(A8,                      0,       0,       0,       pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(ARGB8888,                pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA8888,                pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRX8888,                pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(BGR565,                  VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 6), VTFPP_REMAP_TO_8(pixel.b, 5), 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA5551,                VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 5), VTFPP_REMAP_TO_8(pixel.b, 5), static_cast<uint8_t>(pixel.a * 0xff));
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRX5551,                VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 5), VTFPP_REMAP_TO_8(pixel.b, 5), 1);
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA4444,                VTFPP_REMAP_TO_8(pixel.r, 4), VTFPP_REMAP_TO_8(pixel.g, 4), VTFPP_REMAP_TO_8(pixel.b, 4), VTFPP_REMAP_TO_8(pixel.a, 4));
+		VTFPP_CASE_CONVERT_AND_BREAK(UV88,                    pixel.u, pixel.v, 0,       0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(UVLX8888,                pixel.u, pixel.v, pixel.l, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(RGBX8888,                pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRX8888_LINEAR, pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_RGBA8888_LINEAR, pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_ABGR8888_LINEAR, pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_ARGB8888_LINEAR, pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRA8888_LINEAR, pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_RGB888_LINEAR,   pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGR888_LINEAR,   pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRX5551_LINEAR, VTFPP_REMAP_TO_8(pixel.r, 5), VTFPP_REMAP_TO_8(pixel.g, 5), VTFPP_REMAP_TO_8(pixel.b, 5), 1);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_I8_LINEAR,       pixel.i, pixel.i, pixel.i, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRX8888_LE,     pixel.r, pixel.g, pixel.b, 0xff);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRA8888_LE,     pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(R8,                      pixel.r, 0,       0,       0xff);
 		default: SOURCEPP_DEBUG_BREAK; break;
 	}
 
@@ -377,27 +424,38 @@ namespace {
 
 	switch (format) {
 		using enum ImageFormat;
-		VTFPP_CASE_CONVERT_AND_BREAK(ABGR8888,          {pixel.a, pixel.b, pixel.g, pixel.r});
-		VTFPP_CASE_CONVERT_AND_BREAK(RGB888,            {pixel.r, pixel.g, pixel.b});
-		VTFPP_CASE_CONVERT_AND_BREAK(RGB888_BLUESCREEN, pixel.a < 0xff ? ImagePixel::RGB888_BLUESCREEN{pixel.r, pixel.g, pixel.b} : ImagePixel::RGB888_BLUESCREEN{0, 0, 0xff});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGR888,            {pixel.b, pixel.g, pixel.r});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGR888_BLUESCREEN, pixel.a < 0xff ? ImagePixel::BGR888_BLUESCREEN{pixel.b, pixel.g, pixel.r} : ImagePixel::BGR888_BLUESCREEN{0xff, 0, 0});
-		VTFPP_CASE_CONVERT_AND_BREAK(RGB565,            {VTFPP_REMAP_FROM_8(pixel.r, 5), VTFPP_REMAP_FROM_8(pixel.g, 6), VTFPP_REMAP_FROM_8(pixel.b, 5)});
-		VTFPP_CASE_CONVERT_AND_BREAK(P8,                {pixel.r});
-		VTFPP_CASE_CONVERT_AND_BREAK(I8,                {pixel.r});
-		VTFPP_CASE_CONVERT_AND_BREAK(IA88,              {pixel.r, pixel.a});
-		VTFPP_CASE_CONVERT_AND_BREAK(A8,                {pixel.a});
-		VTFPP_CASE_CONVERT_AND_BREAK(ARGB8888,          {pixel.a, pixel.r, pixel.g, pixel.b});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA8888,          {pixel.b, pixel.g, pixel.r, pixel.a});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRX8888,          {pixel.b, pixel.g, pixel.r, 0xff});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGR565,            {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 6), VTFPP_REMAP_FROM_8(pixel.r, 5)});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA5551,          {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 5), VTFPP_REMAP_FROM_8(pixel.r, 5), static_cast<uint8_t>(pixel.a < 0xff ? 1 : 0)});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRX5551,          {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 5), VTFPP_REMAP_FROM_8(pixel.r, 5), 0x1});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA4444,          {VTFPP_REMAP_FROM_8(pixel.b, 4), VTFPP_REMAP_FROM_8(pixel.g, 4), VTFPP_REMAP_FROM_8(pixel.r, 4), VTFPP_REMAP_FROM_8(pixel.a, 4)});
-		VTFPP_CASE_CONVERT_AND_BREAK(UV88,              {pixel.r, pixel.g});
-		VTFPP_CASE_CONVERT_AND_BREAK(UVLX8888,          {pixel.r, pixel.g, pixel.b});
-		VTFPP_CASE_CONVERT_AND_BREAK(RGBX8888,          {pixel.r, pixel.g, pixel.b, 0xff});
-		VTFPP_CASE_CONVERT_AND_BREAK(R8,                {pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(ABGR8888,                {pixel.a, pixel.b, pixel.g, pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(RGB888,                  {pixel.r, pixel.g, pixel.b});
+		VTFPP_CASE_CONVERT_AND_BREAK(RGB888_BLUESCREEN,       pixel.a < 0xff ? ImagePixel::RGB888_BLUESCREEN{pixel.r, pixel.g, pixel.b} : ImagePixel::RGB888_BLUESCREEN{0, 0, 0xff});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGR888,                  {pixel.b, pixel.g, pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGR888_BLUESCREEN,       pixel.a < 0xff ? ImagePixel::BGR888_BLUESCREEN{pixel.b, pixel.g, pixel.r} : ImagePixel::BGR888_BLUESCREEN{0xff, 0, 0});
+		VTFPP_CASE_CONVERT_AND_BREAK(RGB565,                  {VTFPP_REMAP_FROM_8(pixel.r, 5), VTFPP_REMAP_FROM_8(pixel.g, 6), VTFPP_REMAP_FROM_8(pixel.b, 5)});
+		VTFPP_CASE_CONVERT_AND_BREAK(P8,                      {pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(I8,                      {pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(IA88,                    {pixel.r, pixel.a});
+		VTFPP_CASE_CONVERT_AND_BREAK(A8,                      {pixel.a});
+		VTFPP_CASE_CONVERT_AND_BREAK(ARGB8888,                {pixel.a, pixel.r, pixel.g, pixel.b});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA8888,                {pixel.b, pixel.g, pixel.r, pixel.a});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRX8888,                {pixel.b, pixel.g, pixel.r, 0xff});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGR565,                  {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 6), VTFPP_REMAP_FROM_8(pixel.r, 5)});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA5551,                {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 5), VTFPP_REMAP_FROM_8(pixel.r, 5), static_cast<uint8_t>(pixel.a < 0xff ? 1 : 0)});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRX5551,                {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 5), VTFPP_REMAP_FROM_8(pixel.r, 5), 1});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA4444,                {VTFPP_REMAP_FROM_8(pixel.b, 4), VTFPP_REMAP_FROM_8(pixel.g, 4), VTFPP_REMAP_FROM_8(pixel.r, 4), VTFPP_REMAP_FROM_8(pixel.a, 4)});
+		VTFPP_CASE_CONVERT_AND_BREAK(UV88,                    {pixel.r, pixel.g});
+		VTFPP_CASE_CONVERT_AND_BREAK(UVLX8888,                {pixel.r, pixel.g, pixel.b});
+		VTFPP_CASE_CONVERT_AND_BREAK(RGBX8888,                {pixel.r, pixel.g, pixel.b, 0xff});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRX8888_LINEAR, {pixel.b, pixel.g, pixel.r, 0xff});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_RGBA8888_LINEAR, {pixel.r, pixel.g, pixel.b, pixel.a});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_ABGR8888_LINEAR, {pixel.a, pixel.b, pixel.g, pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_ARGB8888_LINEAR, {pixel.a, pixel.r, pixel.g, pixel.b});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRA8888_LINEAR, {pixel.b, pixel.g, pixel.r, pixel.a});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_RGB888_LINEAR,   {pixel.r, pixel.g, pixel.b});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGR888_LINEAR,   {pixel.b, pixel.g, pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRX5551_LINEAR, {VTFPP_REMAP_FROM_8(pixel.b, 5), VTFPP_REMAP_FROM_8(pixel.g, 5), VTFPP_REMAP_FROM_8(pixel.r, 5), 1});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_I8_LINEAR,       {pixel.r});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRX8888_LE,     {pixel.b, pixel.g, pixel.r, 0xff});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_BGRA8888_LE,     {pixel.b, pixel.g, pixel.r, pixel.a});
+		VTFPP_CASE_CONVERT_AND_BREAK(R8,                      {pixel.r});
 		default: SOURCEPP_DEBUG_BREAK; break;
 	}
 
@@ -466,8 +524,9 @@ namespace {
 
 	switch (format) {
 		using enum ImageFormat;
-		VTFPP_CASE_CONVERT_REMAP_AND_BREAK(RGBA1010102, pixel.r, pixel.g, pixel.b, pixel.a);
-		VTFPP_CASE_CONVERT_REMAP_AND_BREAK(BGRA1010102, pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_REMAP_AND_BREAK(RGBA1010102,           pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_REMAP_AND_BREAK(BGRA1010102,           pixel.r, pixel.g, pixel.b, pixel.a);
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_RGBA16161616_LINEAR, pixel.r, pixel.g, pixel.b, pixel.a);
 		default: SOURCEPP_DEBUG_BREAK; break;
 	}
 
@@ -516,8 +575,9 @@ namespace {
 
 	switch (format) {
 		using enum ImageFormat;
-		VTFPP_CASE_CONVERT_AND_BREAK(RGBA1010102, {VTFPP_REMAP_FROM_16(pixel.r, 10), VTFPP_REMAP_FROM_16(pixel.g, 10), VTFPP_REMAP_FROM_16(pixel.b, 10), VTFPP_REMAP_FROM_16(pixel.a, 2)});
-		VTFPP_CASE_CONVERT_AND_BREAK(BGRA1010102, {VTFPP_REMAP_FROM_16(pixel.b, 10), VTFPP_REMAP_FROM_16(pixel.g, 10), VTFPP_REMAP_FROM_16(pixel.r, 10), VTFPP_REMAP_FROM_16(pixel.a, 2)});
+		VTFPP_CASE_CONVERT_AND_BREAK(RGBA1010102,                 {VTFPP_REMAP_FROM_16(pixel.r, 10), VTFPP_REMAP_FROM_16(pixel.g, 10), VTFPP_REMAP_FROM_16(pixel.b, 10), VTFPP_REMAP_FROM_16(pixel.a, 2)});
+		VTFPP_CASE_CONVERT_AND_BREAK(BGRA1010102,                 {VTFPP_REMAP_FROM_16(pixel.b, 10), VTFPP_REMAP_FROM_16(pixel.g, 10), VTFPP_REMAP_FROM_16(pixel.r, 10), VTFPP_REMAP_FROM_16(pixel.a, 2)});
+		VTFPP_CASE_CONVERT_AND_BREAK(CONSOLE_RGBA16161616_LINEAR, {pixel.r, pixel.g, pixel.b, pixel.a});
 		default: SOURCEPP_DEBUG_BREAK; break;
 	}
 
@@ -1805,6 +1865,7 @@ std::vector<std::byte> ImageConversion::resizeImageDataStrict(std::span<const st
 	return resizeImageData(imageData, format, width, widthOut, height, heightOut, srgb, filter, edge);
 }
 
+// NOLINTNEXTLINE(*-no-recursion)
 std::vector<std::byte> ImageConversion::cropImageData(std::span<const std::byte> imageData, ImageFormat format, uint16_t width, uint16_t newWidth, uint16_t xOffset, uint16_t height, uint16_t newHeight, uint16_t yOffset) {
 	if (imageData.empty() || format == ImageFormat::EMPTY || xOffset + newWidth >= width || yOffset + newHeight >= height) {
 		return {};

--- a/src/vtfpp/VTF.cpp
+++ b/src/vtfpp/VTF.cpp
@@ -522,10 +522,7 @@ void VTF::createInternal(VTF& writer, CreationOptions options) {
 	}
 	writer.setStartFrame(options.startFrame);
 	writer.setBumpMapScale(options.bumpMapScale);
-	if (options.createReflectivity) {
-		writer.computeReflectivity();
-	}
-	if (options.createThumbnail) {
+	if (options.computeThumbnail) {
 		writer.computeThumbnail();
 	}
 	if (options.outputFormat == VTF::FORMAT_UNCHANGED) {
@@ -533,9 +530,12 @@ void VTF::createInternal(VTF& writer, CreationOptions options) {
 	} else if (options.outputFormat == VTF::FORMAT_DEFAULT) {
 		options.outputFormat = writer.getDefaultFormat();
 	}
-	if (options.createMips) {
+	if (options.computeMips) {
 		writer.setMipCount(ImageDimensions::getRecommendedMipCountForDims(options.outputFormat, writer.getWidth(), writer.getHeight()));
 		writer.computeMips();
+	}
+	if (options.computeReflectivity) {
+		writer.computeReflectivity();
 	}
 	writer.setFormat(options.outputFormat);
 	writer.setCompressionLevel(options.compressionLevel);

--- a/src/vtfpp/_vtfpp.cmake
+++ b/src/vtfpp/_vtfpp.cmake
@@ -1,5 +1,5 @@
 add_pretty_parser(vtfpp
-        DEPS miniz libzstd_static sourcepp_parser sourcepp_stb sourcepp_tinyexr
+        DEPS miniz libzstd_static sourcepp_compression sourcepp_parser sourcepp_stb sourcepp_tinyexr
         PRECOMPILED_HEADERS
         "${CMAKE_CURRENT_SOURCE_DIR}/include/vtfpp/ImageConversion.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/include/vtfpp/ImageFormats.h"

--- a/test/vtfpp.cpp
+++ b/test/vtfpp.cpp
@@ -812,6 +812,72 @@ TEST(vtfpp, read_v75_nothumb_nomip) {
 	EXPECT_EQ(image->data.size(), ImageFormatDetails::getDataLength(vtf.getFormat(), vtf.getMipCount(), vtf.getFrameCount(), vtf.getFaceCount(), vtf.getWidth(), vtf.getHeight(), vtf.getSliceCount()));
 }
 
+TEST(vtfpp, read_ps3) {
+	VTF vtf{fs::readFileBuffer(ASSET_ROOT "vtfpp/ps3/portal.vtf")};
+	ASSERT_TRUE(vtf);
+
+	// Header
+	EXPECT_EQ(vtf.getMajorVersion(), 7);
+	EXPECT_EQ(vtf.getMinorVersion(), 4);
+	EXPECT_EQ(vtf.getWidth(), 1024);
+	EXPECT_EQ(vtf.getHeight(), 1024);
+	EXPECT_EQ(vtf.getFlags(), VTF::FLAG_NO_MIP | VTF::FLAG_NO_LOD);
+	EXPECT_EQ(vtf.getFormat(), ImageFormat::DXT1);
+	EXPECT_EQ(vtf.getMipCount(), 1);
+	EXPECT_EQ(vtf.getFrameCount(), 1);
+	EXPECT_EQ(vtf.getFaceCount(), 1);
+	EXPECT_EQ(vtf.getSliceCount(), 1);
+	EXPECT_EQ(vtf.getStartFrame(), 0);
+	EXPECT_FLOAT_EQ(vtf.getReflectivity()[0], 0.037193343f);
+	EXPECT_FLOAT_EQ(vtf.getReflectivity()[1], 0.020529008f);
+	EXPECT_FLOAT_EQ(vtf.getReflectivity()[2], 0.016482241f);
+	EXPECT_FLOAT_EQ(vtf.getBumpMapScale(), 1.f);
+	EXPECT_EQ(vtf.getThumbnailFormat(), ImageFormat::EMPTY);
+	EXPECT_EQ(vtf.getThumbnailWidth(), 0);
+	EXPECT_EQ(vtf.getThumbnailHeight(), 0);
+
+	// Resources
+	EXPECT_EQ(vtf.getResources().size(), 1);
+
+	const auto* image = vtf.getResource(Resource::TYPE_IMAGE_DATA);
+	ASSERT_TRUE(image);
+	EXPECT_EQ(image->flags, Resource::FLAG_NONE);
+	EXPECT_EQ(image->data.size(), ImageFormatDetails::getDataLength(vtf.getFormat(), vtf.getMipCount(), vtf.getFrameCount(), vtf.getFaceCount(), vtf.getWidth(), vtf.getHeight(), vtf.getSliceCount()));
+}
+
+TEST(vtfpp, read_x360) {
+	VTF vtf{fs::readFileBuffer(ASSET_ROOT "vtfpp/x360/metalwall048b.360.vtf")};
+	ASSERT_TRUE(vtf);
+
+	// Header
+	EXPECT_EQ(vtf.getMajorVersion(), 7);
+	EXPECT_EQ(vtf.getMinorVersion(), 4);
+	EXPECT_EQ(vtf.getWidth(), 512);
+	EXPECT_EQ(vtf.getHeight(), 512);
+	EXPECT_EQ(vtf.getFlags(), VTF::FLAG_SRGB | VTF::FLAG_MULTI_BIT_ALPHA);
+	EXPECT_EQ(vtf.getFormat(), ImageFormat::DXT5);
+	EXPECT_EQ(vtf.getMipCount(), 10);
+	EXPECT_EQ(vtf.getFrameCount(), 1);
+	EXPECT_EQ(vtf.getFaceCount(), 1);
+	EXPECT_EQ(vtf.getSliceCount(), 1);
+	EXPECT_EQ(vtf.getStartFrame(), 0);
+	EXPECT_FLOAT_EQ(vtf.getReflectivity()[0], 0.0389036387f);
+	EXPECT_FLOAT_EQ(vtf.getReflectivity()[1], 0.0300185774f);
+	EXPECT_FLOAT_EQ(vtf.getReflectivity()[2], 0.0235184804f);
+	EXPECT_FLOAT_EQ(vtf.getBumpMapScale(), 1.f);
+	EXPECT_EQ(vtf.getThumbnailFormat(), ImageFormat::EMPTY);
+	EXPECT_EQ(vtf.getThumbnailWidth(), 0);
+	EXPECT_EQ(vtf.getThumbnailHeight(), 0);
+
+	// Resources
+	EXPECT_EQ(vtf.getResources().size(), 1);
+
+	const auto* image = vtf.getResource(Resource::TYPE_IMAGE_DATA);
+	ASSERT_TRUE(image);
+	EXPECT_EQ(image->flags, Resource::FLAG_NONE);
+	EXPECT_EQ(image->data.size(), ImageFormatDetails::getDataLength(vtf.getFormat(), vtf.getMipCount(), vtf.getFrameCount(), vtf.getFaceCount(), vtf.getWidth(), vtf.getHeight(), vtf.getSliceCount()));
+}
+
 TEST(vtfpp, read_v76_c9) {
 	VTF vtf{fs::readFileBuffer(ASSET_ROOT "vtfpp/ver/v76_c9.vtf")};
 	ASSERT_TRUE(vtf);


### PR DESCRIPTION
- [x] Add support for console image formats
  - [x] ~~Do linear -> sRGB conversion?~~ Can't find these formats used anywhere, not going to bother
- [x] Read support
  - [x] X360
  - [x] PS3
  - [x] Decompress LZMA-compressed resources
  - [x] Verify `skipMips` is being used correctly
  - [x] Verify all resources besides image resource are being read correctly
    - [x] Convert particle sheet resource from BE -> LE? Apparently no!
  - [x] Fix X360 DXT3/5 endian conversion not being quite right
    - [x] Verify this fix is correct
  - [x] ~~Investigate why certain PS3 textures are read incorrectly~~ Will work on this at a later date
- [x] Implement write support
  - [x] X360
  - [x] PS3
  - [x] Compress LZMA-compressed resources