### PR TITLE
DMX fixes, add support for srctools' unicode "formats"

### DIFF
--- a/include/dmxpp/dmxpp.h
+++ b/include/dmxpp/dmxpp.h
@@ -13,6 +13,8 @@ namespace Format {
 
 constexpr std::string_view TEXT = "keyvalues2";
 constexpr std::string_view BINARY = "binary";
+constexpr std::string_view SRCTOOLS_UTF8_TEXT = "unicode_keyvalues2";
+constexpr std::string_view SRCTOOLS_UTF8_BINARY = "unicode_binary";
 
 } // namespace Format
 

--- a/src/dmxpp/dmxpp.cpp
+++ b/src/dmxpp/dmxpp.cpp
@@ -50,9 +50,10 @@ DMX::DMX(const std::byte* dmxData, std::size_t dmxSize) {
 		return;
 	}
 
-	if (this->encodingType == Format::BINARY) {
+	// Srctools formats indicate that all strings are specifically UTF-8.
+	if (this->encodingType == Format::BINARY || this->encodingType == Format::SRCTOOLS_UTF8_BINARY) {
 		this->opened = this->openBinary(stream);
-	} else if (this->encodingType == Format::TEXT) {
+	} else if (this->encodingType == Format::TEXT || this->encodingType == Format::SRCTOOLS_UTF8_TEXT) {
 		this->opened = this->openText(dmxData, dmxSize);
 	}
 }


### PR DESCRIPTION
This fixes two bugs with parsing DMX files, and adds handling for `srctools`' unicode format, which just indicates all strings are UTF-8, not 'anything ascii-compliant'.