### PR TITLE
vtfpp: remedy crash under libcxx

### DIFF
--- a/src/vtfpp/VTF.cpp
+++ b/src/vtfpp/VTF.cpp
@@ -1662,6 +1662,9 @@ void VTF::setResourceInternal(Resource::Type type, std::span<const std::byte> da
 		}
 		auto& [specificResourceData, offset] = resourceData[resourceType];
 		if (resourceType == type) {
+			if (!this->data.data()) {
+				this->data.reserve(offset + specificResourceData.size());
+			}
 			Resource newResource{
 				type,
 				specificResourceData.size() <= sizeof(uint32_t) ? Resource::FLAG_LOCAL_DATA : Resource::FLAG_NONE,


### PR DESCRIPTION
this one is weird, but `VTF::create(filepath, opts)` would do a null dereference here *specifically* on libcxx under linux. not libstdc++, not libcxx under darwin, just libcxx under linux.